### PR TITLE
Fix for memory leak

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -274,9 +274,9 @@ int parse (size_t size, unsigned char *data) {
       data = MagickWriteImageBlob(output, &size);
       writtendata = io_write(size, data);
       free(data);
+      destroy(input, output);
     }
   }
-  //destroy(input, output);
   return writtendata;
 }
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -273,6 +273,7 @@ int parse (size_t size, unsigned char *data) {
     } else {
       data = MagickWriteImageBlob(output, &size);
       writtendata = io_write(size, data);
+      free(data);
     }
   }
   //destroy(input, output);


### PR DESCRIPTION
When converting images, the image data stays present in the convert process. This change fixes the issue.